### PR TITLE
Delete output from example

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,6 @@ Imports: imager (>= 0.40.1), fftwtools (>= 0.9-7), plotrix (>= 3.2.3),
 License: GPL(>=2)
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.0.1.9000
+RoxygenNote: 7.1.1
 NeedsCompilation: no
 Packaged: 2017-05-08 21:35:15 UTC; ecaves

--- a/R/AcuityView.R
+++ b/R/AcuityView.R
@@ -27,6 +27,10 @@
 #'reef<-load.image(photo)
 #'AcuityView(photo = reef, distance = 2, realWidth = 2, eyeResolutionX = 2,
 #'eyeResolutionY = NULL, plot = TRUE, output="Example.jpeg")
+#'\dontshow{
+#'unlink("Example.jpeg")
+#'}
+#'
 #'@export
 
 AcuityView <- function(photo = NULL, distance = 2, realWidth = 2, eyeResolutionX = 0.2, eyeResolutionY = NULL, plot = T, output="test.jpg"){

--- a/man/AcuityView.Rd
+++ b/man/AcuityView.Rd
@@ -4,9 +4,15 @@
 \alias{AcuityView}
 \title{AcuityView}
 \usage{
-AcuityView(photo = NULL, distance = 2, realWidth = 2,
-  eyeResolutionX = 0.2, eyeResolutionY = NULL, plot = T,
-  output = "test.jpg")
+AcuityView(
+  photo = NULL,
+  distance = 2,
+  realWidth = 2,
+  eyeResolutionX = 0.2,
+  eyeResolutionY = NULL,
+  plot = T,
+  output = "test.jpg"
+)
 }
 \arguments{
 \item{photo}{The photo you wish to alter; if NULL then a pop up window allows you to navigate to your photo, otherwise include the file path here}
@@ -49,4 +55,8 @@ photo<-system.file('extdata/reef.bmp', package='AcuityView')
 reef<-load.image(photo)
 AcuityView(photo = reef, distance = 2, realWidth = 2, eyeResolutionX = 2,
 eyeResolutionY = NULL, plot = TRUE, output="Example.jpeg")
+\dontshow{
+unlink("Example.jpeg")
+}
+
 }


### PR DESCRIPTION
Hi,

This change fixes the problem reported by the automated [CRAN checks](https://cran.r-project.org/web/checks/check_results_AcuityView.html) service:

> Version: 0.1
Check: for non-standard things in the check directory
Result: NOTE
    Found the following files/directories:
     'Example.jpeg'
Flavors: r-devel-linux-x86_64-debian-clang, r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-patched-linux-x86_64, r-patched-solaris-x86, r-release-linux-x86_64

This change will be invisible to the users.

An alternative fix would be to delete this file `Example.jpeg` as part of the example. This prevents users from having a (likely) unwanted `Example.jpeg` file in their working directory when they run this example.